### PR TITLE
Fix: Enable cluster monitoring to address security scan alert

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -28,6 +28,11 @@ resource "oci_containerengine_cluster" "oke_cluster" {
       pods_cidr     = var.pods_cidr
       services_cidr = var.services_cidr
     }
+    
+    # Add monitoring configuration to address security requirement
+    monitoring {
+      enable_monitoring = var.enable_monitoring
+    }
   }
 
   endpoint_config {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -63,3 +63,9 @@ variable "subnet_dependency" {
   type        = any
   default     = null
 }
+
+variable "enable_monitoring" {
+  description = "Whether to enable monitoring for the cluster"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Fixes the security code scanning alert by enabling monitoring for OCI Kubernetes clusters. This PR addresses the issue reported in https://github.com/idvoretskyi/terraform-oci-k8s/security/code-scanning/1 and closes it.

Changes made:
- Added 'enable_monitoring' variable with default value set to true
- Added monitoring configuration block to the OCI Kubernetes cluster resource

Closes #1