### PR TITLE
Fix: Restrict default SSH CIDR to localhost only

### DIFF
--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -32,9 +32,9 @@ variable "worker_subnet_cidr" {
 }
 
 variable "allowed_ssh_cidr" {
-  description = "CIDR block allowed for SSH access"
+  description = "CIDR block allowed for SSH access. For production, specify a restricted IP range."
   type        = string
-  default     = "0.0.0.0/0"  // Should be restricted in production
+  default     = "127.0.0.1/32"  // Default to localhost only - users must explicitly set their allowed IPs
 }
 
 variable "allowed_api_cidr" {


### PR DESCRIPTION
This PR fixes the security issue identified in CKV_OCI_19: "Ensure no security list allow ingress from 0.0.0.0:0 to port 22"

Changes made:
- Changed the default value of  from "0.0.0.0/0" to "127.0.0.1/32" (localhost only)
- Updated the variable description to provide better security guidance

This change ensures that by default, SSH access is restricted rather than open to the internet. Users will need to explicitly specify their allowed SSH CIDR blocks when implementing this module.

Fixes #4