### PR TITLE
Fix: Enable pod security policy enforcement for OKE clusters

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -28,6 +28,10 @@ resource "oci_containerengine_cluster" "oke_cluster" {
       pods_cidr     = var.pods_cidr
       services_cidr = var.services_cidr
     }
+    
+    admission_controller_options {
+      is_pod_security_policy_enabled = var.enable_pod_security_policy
+    }
   }
 
   endpoint_config {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -63,3 +63,9 @@ variable "subnet_dependency" {
   type        = any
   default     = null
 }
+
+variable "enable_pod_security_policy" {
+  description = "Whether to enable pod security policy enforcement for the cluster"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This PR addresses the security issue CKV2_OCI_6: "Ensure Kubernetes Engine Cluster pod security policy is enforced"

Changes made:
- Added new variable "enable_pod_security_policy" defaulted to true
- Added admission controller options to enable pod security policy enforcement

This change ensures that pod security policies are enforced by default in all OKE clusters, which improves the security posture by restricting what containers can do in the cluster.