### PR TITLE
chore: rename repo from oci-k8s-arm to oci-arm-k8s

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,11 +3,11 @@
 
 repository:
   # Repository name and description
-  name: oci-k8s-arm
+  name: oci-arm-k8s
   description: Create an ARM64 Kubernetes cluster (OKE) on Oracle Cloud Infrastructure using OpenTofu
   
   # Homepage URL (pointing to the project documentation)
-  homepage: https://github.com/idvoretskyi/oci-k8s
+  homepage: https://github.com/idvoretskyi/oci-arm-k8s
   
   # Repository topics
   topics:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OCI ARM Kubernetes Cluster
 
-[![Security Scan](https://github.com/idvoretskyi/oci-k8s/actions/workflows/security-scan.yml/badge.svg)](https://github.com/idvoretskyi/oci-k8s/actions/workflows/security-scan.yml)
+[![Security Scan](https://github.com/idvoretskyi/oci-arm-k8s/actions/workflows/security-scan.yml/badge.svg)](https://github.com/idvoretskyi/oci-arm-k8s/actions/workflows/security-scan.yml)
 
 Simple OpenTofu configuration for deploying an ARM-based OKE cluster on Oracle Cloud Infrastructure (OCI). Defaults target the London region and follow Oracle guidance: public subnet for API/LB and private subnet for worker nodes.
 


### PR DESCRIPTION
## Summary

- Updates `settings.yml` repository name and homepage to `oci-arm-k8s`
- Fixes README badge URL to use the correct repository path
- Part of workspace-wide naming audit: standardizes OCI repos on `oci-arm-*` word order (consistent with `oci-arm-dev-env`)

Signed-off-by: Ihor Dvoretskyi <ihor@dvoretskyi.com>