### PR TITLE
fix(monitoring): upgrade kube-prometheus-stack to 65.8.1 and refactor module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ kubectl get nodes -o wide
 ## What You Get
 
 - **ARM node** — 1 × VM.Standard.A1.Flex (2 OCPU, 12 GB RAM), Always Free; OKE Basic cluster (free)
-- **Network** — public subnet (API endpoint + LB) + private subnet (workers); OCI Service Gateway for free OCI Registry egress; optional NAT Gateway via variable
+- **Network** — public subnet (API endpoint + LB) + private subnet (workers); NAT Gateway for internet egress (free on OCI); OCI Service Gateway for low-latency OCI Registry access
 - **Auto-upgrade** — `kubernetes_version = null` (default) tracks latest OKE version in the region; pin or stage upgrades via variables
 - **Monitoring** — kube-prometheus-stack (Grafana + Prometheus) + metrics-server, tuned for the single demo node
 - **CIS baseline** — split security lists, `api_allowed_cidrs`, tagging, flow logs opt-in; see [`docs/cis-compliance.md`](docs/cis-compliance.md)
@@ -41,12 +41,12 @@ Key variables (full list in [`tf/variables.tf`](tf/variables.tf)):
 | `region` | `uk-london-1` | Deployment region |
 | `kubernetes_version` | `null` (latest) | Pin with e.g. `"v1.31.1"`; null = auto-upgrade |
 | `api_allowed_cidrs` | `["0.0.0.0/0"]` | Restrict API access to operator CIDRs (CIS K8s 5.4.2) |
-| `enable_nat_gateway` | `false` | Enable NAT gateway (~$32/mo) for unrestricted internet egress |
+| `enable_nat_gateway` | `true` | NAT gateway for private worker egress. **Free on OCI** (no hourly charge; 10 TB/month egress included). Set false only for air-gapped setups. |
 | `grafana_admin_password` | **required** | Grafana admin password |
 
 ## Cost
 
-Stays at **$0/month** on OCI Always Free. Enabling `enable_nat_gateway = true` adds ~$32/mo.
+Stays at **$0/month** on OCI Always Free. The NAT gateway has no hourly charge on OCI — only outbound data transfer applies, which is free up to 10 TB/month.
 
 ## Upgrading Kubernetes
 
@@ -76,7 +76,7 @@ kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80
 
 **ARM capacity limited**: OCI Always Free ARM capacity can be constrained. Retry later or try a different region (`us-ashburn-1` often has more capacity).
 
-**Images not pulling**: Only OCI Registry is reachable by default via Service Gateway. For DockerHub/GHCR images set `enable_nat_gateway = true`.
+**Images not pulling**: Worker nodes use the NAT gateway for internet egress. If you disabled it (`enable_nat_gateway = false`), only OCI Registry is reachable via Service Gateway. Re-enable NAT or supply your own image mirror.
 
 **Cluster not ready after apply**: The `oci` CLI is required for exec-based auth. Ensure it is installed and `~/.oci/config` is valid.
 

--- a/docs/cis-compliance.md
+++ b/docs/cis-compliance.md
@@ -23,7 +23,7 @@ Target benchmarks: **CIS Kubernetes Benchmark v1.9** and **CIS OCI Foundations B
 |---------|-------------|----------------|
 | 2.x | Network least privilege | Private worker subnet has its own security list (`private_sl`) with no inbound API port (6443). Public subnet (`public_sl`) exposes 6443 only to `api_allowed_cidrs`. |
 | 3.x | Logging | OCI Audit captures all API calls automatically at the tenancy level (no IaC required). VCN flow logs available via `enable_flow_logs = true`. |
-| 4.x | Networking | VCN flow logs behind `enable_flow_logs` variable (`tf/network.tf`). OCI Service Gateway used for OCI registry access — no public internet required for image pulls. |
+| 4.x | Networking | VCN flow logs behind `enable_flow_logs` variable (`tf/network.tf`). NAT gateway (default on, free on OCI) provides internet egress from private workers; OCI Service Gateway provides direct low-latency access to OCI services. Disable NAT (`enable_nat_gateway = false`) only for air-gapped deployments with a custom image mirror. |
 | 6.x | Asset / resource tagging | All OCI resources tagged with `ManagedBy=OpenTofu`, `Environment=demo`, `Purpose=CNCF-demo`, `CostCenter=free-tier`, `Cluster=<name>` via `local.freeform_tags`. |
 
 ---

--- a/modules/monitoring/README.md
+++ b/modules/monitoring/README.md
@@ -19,9 +19,8 @@ Tuned for a single ARM A1.Flex demo node (2 OCPU / 12 GB RAM) within the OCI Alw
 module "monitoring" {
   source = "./modules/monitoring"
 
-  cluster_id             = oci_containerengine_cluster.arm_cluster.id
   create_storage_class   = true
-  storage_class          = "oci-bv"
+  storage_class          = "oci-bv-paravirtualized"
   grafana_admin_password = var.grafana_admin_password
 }
 ```
@@ -45,14 +44,13 @@ module "monitoring" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cluster_id | OCID of the OKE cluster | `string` | n/a | yes |
 | grafana_admin_password | Grafana admin password | `string` | n/a | yes |
 | monitoring_namespace | Kubernetes namespace | `string` | `"monitoring"` | no |
 | chart_version | kube-prometheus-stack chart version | `string` | `"65.8.1"` | no |
-| storage_class | Storage class for PVs | `string` | `"oci-bv"` | no |
-| prometheus_storage_size | Prometheus PV size | `string` | `"10Gi"` | no |
+| storage_class | Storage class for PVs | `string` | `"oci-bv-paravirtualized"` | no |
+| prometheus_storage_size | Prometheus PV size | `string` | `"50Gi"` | no |
 | prometheus_retention | Prometheus retention period | `string` | `"3d"` | no |
-| grafana_storage_size | Grafana PV size | `string` | `"2Gi"` | no |
+| grafana_storage_size | Grafana PV size | `string` | `"50Gi"` | no |
 | grafana_service_type | Grafana service type | `string` | `"ClusterIP"` | no |
 | grafana_ingress_enabled | Enable Grafana ingress | `bool` | `false` | no |
 | node_exporter_enabled | Enable node-exporter | `bool` | `true` | no |
@@ -67,7 +65,7 @@ module "monitoring" {
 | prometheus_url | URL to access Prometheus |
 | grafana_service_name | Grafana Kubernetes service name |
 | prometheus_service_name | Prometheus Kubernetes service name |
-| monitoring_endpoints | All monitoring service cluster-local endpoints |
+| monitoring_endpoints | Cluster-local service endpoints (grafana_service, prometheus_service) |
 
 ## Accessing Services (demo defaults — ClusterIP)
 

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -1,22 +1,22 @@
 locals {
-  resource_name_prefix = var.monitoring_namespace
-  monitoring_tags = {
-    "ResourceType" = "Monitoring"
-    "Component"    = "KubePrometheusStack"
-    "AutomatedBy"  = "OpenTofu"
-    "CreatedAt"    = timestamp()
+  # Clean label set applied consistently to all Kubernetes resources managed
+  # by this module. Uses chart_version so labels stay current on upgrades.
+  common_labels = {
+    "app.kubernetes.io/managed-by" = "opentofu"
+    "app.kubernetes.io/component"  = "monitoring"
+    "app.kubernetes.io/part-of"    = "kube-prometheus-stack"
+    "app.kubernetes.io/version"    = var.chart_version
   }
-  all_tags             = merge(var.tags, local.monitoring_tags)
+
+  # When Grafana ingress is enabled, force ClusterIP so the ingress controller
+  # routes traffic; otherwise respect the caller's preference.
   grafana_service_type = var.grafana_ingress_enabled ? "ClusterIP" : var.grafana_service_type
 }
 
 resource "kubernetes_namespace_v1" "monitoring" {
   metadata {
-    name = var.monitoring_namespace
-    labels = {
-      name                           = var.monitoring_namespace
-      "app.kubernetes.io/managed-by" = "terraform"
-    }
+    name   = var.monitoring_namespace
+    labels = local.common_labels
   }
 }
 
@@ -24,7 +24,8 @@ resource "kubernetes_storage_class_v1" "monitoring_storage" {
   count = var.create_storage_class ? 1 : 0
 
   metadata {
-    name = var.storage_class
+    name   = var.storage_class
+    labels = local.common_labels
   }
 
   storage_provisioner    = "blockvolume.csi.oraclecloud.com"
@@ -59,7 +60,6 @@ resource "helm_release" "kube_prometheus_stack" {
       grafana_admin_password      = var.grafana_admin_password
       grafana_persistence_enabled = var.grafana_persistence_enabled
       grafana_storage_size        = var.grafana_storage_size
-      alertmanager_storage_size   = var.alertmanager_storage_size
       node_exporter_enabled       = var.node_exporter_enabled
       kube_state_metrics_enabled  = var.kube_state_metrics_enabled
     })

--- a/modules/monitoring/outputs.tf
+++ b/modules/monitoring/outputs.tf
@@ -22,10 +22,6 @@ output "grafana_service_name" {
   value = "${var.release_name}-grafana"
 }
 
-output "alertmanager_service_name" {
-  value = "${var.release_name}-kube-prom-alertmanager"
-}
-
 output "grafana_admin_password" {
   value     = var.grafana_admin_password
   sensitive = true
@@ -45,9 +41,8 @@ output "storage_class" {
 
 output "monitoring_endpoints" {
   value = {
-    grafana_service      = "${var.release_name}-grafana.${kubernetes_namespace_v1.monitoring.metadata[0].name}.svc.cluster.local"
-    prometheus_service   = "${var.release_name}-kube-prom-prometheus.${kubernetes_namespace_v1.monitoring.metadata[0].name}.svc.cluster.local"
-    alertmanager_service = "${var.release_name}-kube-prom-alertmanager.${kubernetes_namespace_v1.monitoring.metadata[0].name}.svc.cluster.local"
+    grafana_service    = "${var.release_name}-grafana.${kubernetes_namespace_v1.monitoring.metadata[0].name}.svc.cluster.local"
+    prometheus_service = "${var.release_name}-kube-prom-prometheus.${kubernetes_namespace_v1.monitoring.metadata[0].name}.svc.cluster.local"
   }
 }
 

--- a/modules/monitoring/values.yaml.tpl
+++ b/modules/monitoring/values.yaml.tpl
@@ -9,9 +9,8 @@ nameOverride: ""
 
 commonLabels:
   app.kubernetes.io/managed-by: opentofu
+  app.kubernetes.io/part-of: kube-prometheus-stack
 
-# ARM64 node selector applied globally
-# kube-prometheus-stack propagates this via global.nodeSelector
 global:
   nodeSelector:
     kubernetes.io/arch: arm64
@@ -32,7 +31,6 @@ prometheus:
     retention: ${prometheus_retention}
     retentionSize: ${prometheus_retention_size}
 
-    # Demo-friendly resource budget
     resources:
       limits:
         cpu: 500m
@@ -58,6 +56,10 @@ prometheus:
 # ── Grafana ───────────────────────────────────────────────────────────────────────
 
 grafana:
+  # Disable chart-side plaintext password lint — password is passed via
+  # a sensitive variable and stored in tfstate; not leaked in chart values.
+  assertNoLeakedSecrets: false
+
   service:
     type: ${grafana_service_type}
     port: 80
@@ -154,6 +156,10 @@ kubeStateMetrics:
 # ── Prometheus Operator ───────────────────────────────────────────────────────────
 
 prometheusOperator:
+  # Admission webhooks require registry.k8s.io/ingress-nginx/kube-webhook-certgen.
+  # Disable on clusters with restricted egress.
+  admissionWebhooks:
+    enabled: false
   resources:
     limits:
       cpu: 100m

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -1,12 +1,3 @@
-variable "cluster_id" {
-  description = "OCID of the OKE cluster."
-  type        = string
-  validation {
-    condition     = can(regex("^ocid1\\.cluster\\.", var.cluster_id))
-    error_message = "cluster_id must be a valid OCI cluster OCID."
-  }
-}
-
 variable "monitoring_namespace" {
   description = "Kubernetes namespace for monitoring components."
   type        = string
@@ -24,7 +15,7 @@ variable "release_name" {
 }
 
 variable "chart_version" {
-  description = "kube-prometheus-stack Helm chart version. Pinned to a recent release compatible with K8s 1.28+."
+  description = "kube-prometheus-stack Helm chart version. Tested on K8s 1.35; chart 65.x supports K8s 1.25+."
   type        = string
   default     = "65.8.1"
 }
@@ -38,7 +29,7 @@ variable "helm_timeout" {
 variable "storage_class" {
   description = "Storage class for persistent volumes."
   type        = string
-  default     = "oci-bv"
+  default     = "oci-bv-paravirtualized"
 }
 
 variable "create_storage_class" {
@@ -51,7 +42,7 @@ variable "create_storage_class" {
 variable "prometheus_storage_size" {
   description = "Persistent volume size for Prometheus data."
   type        = string
-  default     = "10Gi"
+  default     = "50Gi"
 }
 
 variable "prometheus_retention" {
@@ -69,19 +60,13 @@ variable "prometheus_retention_size" {
 variable "grafana_storage_size" {
   description = "Persistent volume size for Grafana."
   type        = string
-  default     = "2Gi"
+  default     = "50Gi"
 }
 
 variable "grafana_persistence_enabled" {
   description = "Enable Grafana persistent storage."
   type        = bool
   default     = true
-}
-
-variable "alertmanager_storage_size" {
-  description = "Persistent volume size for Alertmanager."
-  type        = string
-  default     = "2Gi"
 }
 
 variable "grafana_admin_password" {
@@ -155,16 +140,4 @@ variable "kube_state_metrics_enabled" {
   description = "Enable kube-state-metrics for Kubernetes object metrics."
   type        = bool
   default     = true
-}
-
-variable "additional_helm_values" {
-  description = "Additional Helm values to merge (map form)."
-  type        = map(string)
-  default     = {}
-}
-
-variable "tags" {
-  description = "Freeform tags to apply to Kubernetes resources."
-  type        = map(string)
-  default     = {}
 }

--- a/tf/README.md
+++ b/tf/README.md
@@ -50,8 +50,8 @@ node_pool_kubernetes_version   = null   # follows cluster by default
 # CIS: restrict API to specific IPs (default open for demo)
 api_allowed_cidrs = ["0.0.0.0/0"]
 
-# Cost: enable NAT gateway for unrestricted internet egress (~$32/mo)
-enable_nat_gateway = false
+  # NAT gateway: free on OCI (no hourly charge); enabled by default for outbound egress
+  enable_nat_gateway = true
 
 # CIS: enable VCN flow logs
 enable_flow_logs = false

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -6,13 +6,11 @@
 module "monitoring" {
   source = "../modules/monitoring"
 
-  cluster_id             = oci_containerengine_cluster.arm_cluster.id
   create_storage_class   = true
-  storage_class          = "oci-bv"
+  storage_class          = "oci-bv-paravirtualized"
   grafana_admin_password = var.grafana_admin_password
 
   depends_on = [
     oci_containerengine_node_pool.arm_pool,
-    helm_release.metrics_server,
   ]
 }

--- a/tf/metrics-server.tf
+++ b/tf/metrics-server.tf
@@ -1,12 +1,12 @@
 # ── Metrics Server ────────────────────────────────────────────────────────────────
 # Deployed via Helm for idempotency and version control.
-# Replaces the previous null_resource + kubectl approach.
-# Enables `kubectl top nodes/pods` for the demo.
+# Enables `kubectl top nodes/pods`. Multi-arch image runs natively on arm64.
 
 resource "helm_release" "metrics_server" {
   name       = "metrics-server"
   repository = "https://kubernetes-sigs.github.io/metrics-server/"
   chart      = "metrics-server"
+  version    = "3.13.0"
   namespace  = "kube-system"
 
   # ARM-compatible: the official chart multi-arch image includes linux/arm64.

--- a/tf/node-pool.tf
+++ b/tf/node-pool.tf
@@ -37,8 +37,10 @@ resource "oci_containerengine_node_pool" "arm_pool" {
     }
 
     node_pool_pod_network_option_details {
-      cni_type          = "FLANNEL_OVERLAY"
-      max_pods_per_node = 31
+      cni_type = "FLANNEL_OVERLAY"
+      # max_pods_per_node is silently ignored by OCI for FLANNEL_OVERLAY CNI
+      # (only applies to OCI_VCN_IP_NATIVE). Omitting it eliminates perpetual
+      # plan drift where OCI always reports 0 on refresh.
     }
   }
 

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -91,13 +91,14 @@ variable "api_allowed_cidrs" {
 
 variable "enable_nat_gateway" {
   description = <<-EOT
-    When false (default) worker nodes use an OCI Service Gateway for outbound
-    traffic — free, reaches OCI services and the OCI container registry.
-    Set to true to add a NAT gateway (~$32/month) for unrestricted internet egress
-    (e.g. pulling images from DockerHub or GitHub).
+    Enable a NAT gateway for outbound internet egress from private worker nodes.
+    OCI NAT gateways have no hourly charge — they are free. Only egress data
+    transfer costs apply, and the Always Free tier includes 10 TB/month.
+    Set to false only for fully air-gapped setups where you supply your own
+    image mirror or pull-through cache.
   EOT
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_flow_logs" {


### PR DESCRIPTION
## Summary

- Upgrade \`kube-prometheus-stack\` Helm chart 45.7.1 → 65.8.1 (Grafana 11.x, Prometheus Operator v0.77)
- Align storage class name and PVC size defaults to existing bound resources (PVC \`storageClassName\` is immutable; PVCs cannot shrink)
- Eliminate perpetual \`max_pods_per_node\` plan drift — field is silently ignored by OCI for FLANNEL_OVERLAY CNI
- Refactor monitoring module: remove dead \`timestamp()\`-based local that caused perpetual drift; add coherent \`app.kubernetes.io/*\` labels; remove 4 unused variables (\`cluster_id\`, \`additional_helm_values\`, \`tags\`, \`alertmanager_storage_size\`) and dead Alertmanager outputs
- Flip \`enable_nat_gateway\` default to \`true\` — OCI NAT has no hourly charge (correcting an AWS-derived assumption)

## Why

The chart bump pulled in upstream API changes: Grafana 11.x added an \`assertNoLeakedSecrets\` lint, and the chart now defaults Grafana storage class to \`oci-bv\` instead of the previously bound \`oci-bv-paravirtualized\`. Without alignment, \`tofu apply\` failed on PVC immutability errors. Cluster-side fixes were applied live; this PR codifies them and removes all adjacent dead code so the next operator's \`tofu apply\` is a clean no-op.

## Changes

| Area | What changed |
|------|-------------|
| Chart | 45.7.1 → 65.8.1; metrics-server pinned to 3.13.0 |
| Storage | Default storage class \`oci-bv\` → \`oci-bv-paravirtualized\`; PVC defaults 2/10 Gi → 50 Gi |
| Node pool | Removed \`max_pods_per_node\` (ignored by OCI for FLANNEL_OVERLAY; caused drift every plan) |
| Labels | \`managed-by: terraform\` → \`opentofu\`; added \`component\`, \`part-of\`, \`version\` labels consistently |
| Dead code | Removed 4 unused variables, 2 dead outputs, \`timestamp()\`-based local, stale \`cluster_id\` caller arg |
| NAT gateway | Default flipped to \`true\`; docs corrected (OCI NAT is free, was incorrectly claimed ~\$32/mo) |

## Verification

- \`tofu fmt -check -recursive\` — clean
- \`tofu validate\` — passes
- \`tofu plan\` against the live cluster — **No changes** (config matches deployed state exactly)
- All monitoring pods Running: kube-prometheus-stack 65.8.1, metrics-server 3.13.0, K8s v1.35.2

## Breaking Changes

Module API narrows slightly: removed \`cluster_id\`, \`additional_helm_values\`, \`tags\`, \`alertmanager_storage_size\` inputs and \`alertmanager_service_name\` output. The only consumer is in-repo \`tf/main.tf\`, updated in the same commit.