### PR TITLE
feat(tf): auto-discover region/compartment from ~/.oci/config; auto-generate Grafana password

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,20 @@ Requires: OCI CLI configured (`~/.oci/config`), [OpenTofu](https://opentofu.org)
 ```bash
 cd tf
 tofu init
-tofu apply -var='compartment_ocid=<your-compartment-ocid>' \
-           -var='grafana_admin_password=<your-password>'
+tofu apply
 ```
+
+That's it — no `-var` flags needed. Region, tenancy/compartment, and Grafana password are all resolved automatically (see [Authentication & defaults](#authentication--defaults) below).
 
 Configure kubectl:
 ```bash
-tofu output kubeconfig_command  # prints the oci ce cluster create-kubeconfig command
-# run the printed command, then:
+eval "$(tofu output -raw kubeconfig_command)"
 kubectl get nodes -o wide
+```
+
+Retrieve the auto-generated Grafana password:
+```bash
+tofu output -raw grafana_admin_password
 ```
 
 ## What You Get
@@ -31,18 +36,56 @@ kubectl get nodes -o wide
 - **Monitoring** — kube-prometheus-stack (Grafana + Prometheus) + metrics-server, tuned for the single demo node
 - **CIS baseline** — split security lists, `api_allowed_cidrs`, tagging, flow logs opt-in; see [`docs/cis-compliance.md`](docs/cis-compliance.md)
 
+## Authentication & defaults
+
+All values are auto-discovered from `~/.oci/config` (the same file used by the OCI CLI). Precedence for each value (highest wins):
+
+| Source | How |
+|--------|-----|
+| Explicit `-var` flag or `TF_VAR_*` env var | `-var='region=us-ashburn-1'` |
+| `terraform.tfvars` / `*.auto.tfvars` (gitignored) | `region = "us-ashburn-1"` |
+| `~/.oci/config` profile (default: `DEFAULT`) | auto-read by OpenTofu |
+| Error | friendly message if value cannot be resolved |
+
+The profile used defaults to `DEFAULT`. Override with `-var='oci_profile=MYPROFILE'`.
+
+**What is auto-discovered:**
+
+| Value | Source |
+|-------|--------|
+| `region` | `region` key in `~/.oci/config` |
+| `compartment_ocid` | `tenancy` key in `~/.oci/config` (= root compartment OCID) |
+| `grafana_admin_password` | 24-char random password, generated once and stored in state |
+| API credentials (user, fingerprint, key) | Read directly by the OCI provider from `~/.oci/config` |
+
+To override any value, pass it as a variable:
+```bash
+tofu apply \
+  -var='compartment_ocid=ocid1.compartment.oc1..xxx' \
+  -var='region=us-ashburn-1' \
+  -var='grafana_admin_password=mysecret'
+```
+
+Or create a gitignored `terraform.tfvars`:
+```hcl
+compartment_ocid       = "ocid1.compartment.oc1..xxx"
+region                 = "us-ashburn-1"
+grafana_admin_password = "mysecret"
+```
+
 ## Configuration
 
 Key variables (full list in [`tf/variables.tf`](tf/variables.tf)):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `compartment_ocid` | **required** | OCI compartment OCID |
-| `region` | `uk-london-1` | Deployment region |
+| `oci_profile` | `DEFAULT` | Profile name to read from `~/.oci/config` |
+| `compartment_ocid` | `null` (from `~/.oci/config`) | OCI compartment OCID; defaults to root compartment |
+| `region` | `null` (from `~/.oci/config`) | Deployment region |
 | `kubernetes_version` | `null` (latest) | Pin with e.g. `"v1.31.1"`; null = auto-upgrade |
 | `api_allowed_cidrs` | `["0.0.0.0/0"]` | Restrict API access to operator CIDRs (CIS K8s 5.4.2) |
-| `enable_nat_gateway` | `true` | NAT gateway for private worker egress. **Free on OCI** (no hourly charge; 10 TB/month egress included). Set false only for air-gapped setups. |
-| `grafana_admin_password` | **required** | Grafana admin password |
+| `enable_nat_gateway` | `true` | NAT gateway for private worker egress. **Free on OCI**. |
+| `grafana_admin_password` | `null` (auto-generated) | Retrieve with `tofu output -raw grafana_admin_password` |
 
 ## Cost
 
@@ -69,7 +112,9 @@ tofu output latest_available_kubernetes_version
 
 ```bash
 kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80
-# open http://localhost:3000  (admin / <grafana_admin_password>)
+# open http://localhost:3000
+# username: admin
+# password: $(tofu output -raw grafana_admin_password)
 ```
 
 ## Troubleshooting
@@ -79,6 +124,8 @@ kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80
 **Images not pulling**: Worker nodes use the NAT gateway for internet egress. If you disabled it (`enable_nat_gateway = false`), only OCI Registry is reachable via Service Gateway. Re-enable NAT or supply your own image mirror.
 
 **Cluster not ready after apply**: The `oci` CLI is required for exec-based auth. Ensure it is installed and `~/.oci/config` is valid.
+
+**region/compartment not resolved**: If `~/.oci/config` is missing or the profile doesn't exist, OpenTofu will print a clear error. Pass the values explicitly via `-var` or create a `terraform.tfvars`.
 
 ## Further Reading
 

--- a/tf/README.md
+++ b/tf/README.md
@@ -6,55 +6,89 @@ OpenTofu configuration for a single-node ARM OKE cluster on OCI, sized for the A
 
 ```
 tf/
-├── variables.tf     — All input variables
-├── locals.tf        — Computed locals (versions, tags, names)
-├── provider.tf      — OCI, Kubernetes, Helm providers
-├── network.tf       — VCN, gateways, route tables, security lists, NSG, subnets
-├── cluster.tf       — OKE cluster resource
-├── node-pool.tf     — ARM node pool resource
+├── variables.tf      — All input variables
+├── locals.tf         — OCI config discovery, computed locals, random password resource
+├── provider.tf       — OCI, Kubernetes, Helm, Random providers
+├── network.tf        — VCN, gateways, route tables, security lists, NSG, subnets
+├── cluster.tf        — OKE cluster resource
+├── node-pool.tf      — ARM node pool resource
 ├── metrics-server.tf — metrics-server Helm release
-├── main.tf          — Monitoring module call
-└── outputs.tf       — All outputs
+├── main.tf           — Monitoring module call
+└── outputs.tf        — All outputs
 ```
 
 ## Quick Start
 
 ```bash
 tofu init
-tofu plan -var='compartment_ocid=ocid1.compartment.oc1..xxx' \
-          -var='grafana_admin_password=changeme'
-tofu apply -var='compartment_ocid=ocid1.compartment.oc1..xxx' \
-           -var='grafana_admin_password=changeme'
+tofu apply   # zero args — reads ~/.oci/config automatically
 ```
 
-Or create a `terraform.tfvars` (gitignored):
+Retrieve the Grafana password after apply:
+```bash
+tofu output -raw grafana_admin_password
+```
+
+## OCI config auto-discovery
+
+Values are resolved in this order (highest priority first):
+
+1. Explicit `-var` flag or `TF_VAR_*` environment variable
+2. `terraform.tfvars` / `*.auto.tfvars` (gitignored)
+3. `~/.oci/config` — profile specified by `var.oci_profile` (default: `DEFAULT`)
+4. Error with a descriptive message
+
+| Value | Auto-source |
+|-------|-------------|
+| `region` | `region` key in the config profile |
+| `compartment_ocid` | `tenancy` key (root compartment OCID) |
+| `grafana_admin_password` | 24-char random password, stable across applies |
+| API credentials | Read by the OCI provider natively from `~/.oci/config` |
+
+To use a non-default profile:
+```bash
+tofu apply -var='oci_profile=MYPROFILE'
+```
+
+To override individual values:
 ```hcl
+# terraform.tfvars (gitignored)
 compartment_ocid       = "ocid1.compartment.oc1..xxx"
-grafana_admin_password = "changeme"
+region                 = "us-ashburn-1"
+grafana_admin_password = "mysecret"
 ```
 
 ## Key Variables
 
 ```hcl
-# Defaults — no changes needed for a basic demo
+# OCI config profile (default: reads [DEFAULT] from ~/.oci/config)
+oci_profile = "DEFAULT"
+
+# Region and compartment: null = auto-discovered from ~/.oci/config
+region           = null
+compartment_ocid = null
+
+# Cluster defaults — no changes needed for a basic demo
 cluster_name   = "arm-oke-demo"
-region         = "uk-london-1"
 node_count     = 1
 node_ocpus     = 2
 node_memory_gb = 12
 
 # K8s version: null = always latest, auto-upgrades on each apply
-kubernetes_version             = null
-node_pool_kubernetes_version   = null   # follows cluster by default
+kubernetes_version           = null
+node_pool_kubernetes_version = null   # follows cluster by default
 
 # CIS: restrict API to specific IPs (default open for demo)
 api_allowed_cidrs = ["0.0.0.0/0"]
 
-  # NAT gateway: free on OCI (no hourly charge); enabled by default for outbound egress
-  enable_nat_gateway = true
+# NAT gateway: free on OCI (no hourly charge); enabled by default for outbound egress
+enable_nat_gateway = true
 
 # CIS: enable VCN flow logs
 enable_flow_logs = false
+
+# Grafana password: null = auto-generated; retrieve with: tofu output -raw grafana_admin_password
+grafana_admin_password = null
 ```
 
 ## Upgrading Kubernetes
@@ -93,7 +127,7 @@ tofu output latest_available_kubernetes_version
 ## Verify Cluster
 
 ```bash
-# Get the kubeconfig command from outputs
+# Configure kubectl from outputs
 eval "$(tofu output -raw kubeconfig_command)"
 
 kubectl get nodes -o wide
@@ -104,7 +138,7 @@ kubectl get pods -A
 ## Cleanup
 
 ```bash
-tofu destroy -var='compartment_ocid=...' -var='grafana_admin_password=...'
+tofu destroy
 ```
 
 ## ARM Notes

--- a/tf/cluster.tf
+++ b/tf/cluster.tf
@@ -2,7 +2,7 @@
 
 data "oci_containerengine_cluster_option" "options" {
   cluster_option_id = "all"
-  compartment_id    = var.compartment_ocid
+  compartment_id    = local.effective_compartment_ocid
 }
 
 # ── OKE Cluster ───────────────────────────────────────────────────────────────────
@@ -13,7 +13,7 @@ data "oci_containerengine_cluster_option" "options" {
 # (Kyverno / OPA Gatekeeper) for runtime enforcement.
 
 resource "oci_containerengine_cluster" "arm_cluster" {
-  compartment_id     = var.compartment_ocid
+  compartment_id     = local.effective_compartment_ocid
   kubernetes_version = local.kubernetes_version
   name               = local.cluster_name
   vcn_id             = oci_core_vcn.vcn.id

--- a/tf/locals.tf
+++ b/tf/locals.tf
@@ -2,6 +2,39 @@ locals {
   # ── Cluster identity ───────────────────────────────────────────────────────────
   cluster_name = var.cluster_name
 
+  # ── OCI config auto-discovery ─────────────────────────────────────────────────
+  # Read ~/.oci/config to derive region and compartment_ocid when not explicitly
+  # supplied via variables. This makes `tofu apply` zero-argument for typical
+  # local development: credentials, region, and tenancy all come from the same
+  # file the OCI CLI uses.
+  #
+  # Precedence (highest to lowest):
+  #   1. Explicit -var / TF_VAR_* / terraform.tfvars value
+  #   2. Value parsed from ~/.oci/config ([oci_profile] stanza, default: DEFAULT)
+  #   3. Error via check block below
+
+  oci_config_path = pathexpand("~/.oci/config")
+  oci_config_raw  = fileexists(local.oci_config_path) ? file(local.oci_config_path) : ""
+
+  # Extract the named profile block (everything between [PROFILE] and the next
+  # [SECTION] header or end-of-file).
+  _oci_profile_block = try(
+    regex(
+      "(?ms)^\\[${var.oci_profile}\\][^\\[]*",
+      local.oci_config_raw
+    ),
+    ""
+  )
+
+  # Pull individual keys out of the profile block.
+  oci_tenancy_from_config = try(regex("(?m)^tenancy\\s*=\\s*(\\S+)", local._oci_profile_block)[0], null)
+  oci_region_from_config  = try(regex("(?m)^region\\s*=\\s*(\\S+)", local._oci_profile_block)[0], null)
+
+  # Effective values used throughout the configuration.
+  effective_region           = coalesce(var.region, local.oci_region_from_config)
+  effective_compartment_ocid = coalesce(var.compartment_ocid, local.oci_tenancy_from_config)
+  effective_grafana_password = coalesce(var.grafana_admin_password, random_password.grafana[0].result)
+
   # ── Kubernetes versions ────────────────────────────────────────────────────────
   # latest_kubernetes_version: last entry in the sorted list OCI returns.
   latest_kubernetes_version = (
@@ -30,5 +63,25 @@ locals {
     Purpose     = "CNCF-demo"
     CostCenter  = "free-tier"
     Cluster     = local.cluster_name
+  }
+}
+
+# ── Grafana password auto-generation ──────────────────────────────────────────
+# Generated only when var.grafana_admin_password is null (the default).
+# The result is stored in state and stable across applies.
+resource "random_password" "grafana" {
+  count            = var.grafana_admin_password == null ? 1 : 0
+  length           = 24
+  special          = true
+  override_special = "!@#$%^&*()-_=+"
+}
+
+# ── Sanity check: ensure region and compartment could be resolved ──────────────
+# Triggers a clear error if ~/.oci/config is missing/malformed and neither
+# variable was supplied explicitly.
+check "oci_config_discoverable" {
+  assert {
+    condition     = local.effective_region != null && local.effective_compartment_ocid != null
+    error_message = "Could not resolve region or compartment_ocid. Either supply -var='region=...' and -var='compartment_ocid=...' explicitly, or ensure ~/.oci/config exists with a valid [${var.oci_profile}] profile containing 'region' and 'tenancy'."
   }
 }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -8,7 +8,7 @@ module "monitoring" {
 
   create_storage_class   = true
   storage_class          = "oci-bv-paravirtualized"
-  grafana_admin_password = var.grafana_admin_password
+  grafana_admin_password = local.effective_grafana_password
 
   depends_on = [
     oci_containerengine_node_pool.arm_pool,

--- a/tf/network.tf
+++ b/tf/network.tf
@@ -1,7 +1,7 @@
 # ── VCN ─────────────────────────────────────────────────────────────────────────
 
 resource "oci_core_vcn" "vcn" {
-  compartment_id = var.compartment_ocid
+  compartment_id = local.effective_compartment_ocid
   cidr_blocks    = ["10.0.0.0/16"]
   display_name   = "${local.cluster_name}-vcn"
   dns_label      = "armokecluster"
@@ -11,7 +11,7 @@ resource "oci_core_vcn" "vcn" {
 # ── Internet Gateway (public subnet / LB / API endpoint) ────────────────────────
 
 resource "oci_core_internet_gateway" "igw" {
-  compartment_id = var.compartment_ocid
+  compartment_id = local.effective_compartment_ocid
   vcn_id         = oci_core_vcn.vcn.id
   display_name   = "${local.cluster_name}-igw"
   freeform_tags  = local.freeform_tags
@@ -29,7 +29,7 @@ locals {
 }
 
 resource "oci_core_service_gateway" "sgw" {
-  compartment_id = var.compartment_ocid
+  compartment_id = local.effective_compartment_ocid
   vcn_id         = oci_core_vcn.vcn.id
   display_name   = "${local.cluster_name}-sgw"
   freeform_tags  = local.freeform_tags
@@ -45,7 +45,7 @@ resource "oci_core_service_gateway" "sgw" {
 
 resource "oci_core_nat_gateway" "ngw" {
   count          = var.enable_nat_gateway ? 1 : 0
-  compartment_id = var.compartment_ocid
+  compartment_id = local.effective_compartment_ocid
   vcn_id         = oci_core_vcn.vcn.id
   display_name   = "${local.cluster_name}-ngw"
   freeform_tags  = local.freeform_tags
@@ -54,7 +54,7 @@ resource "oci_core_nat_gateway" "ngw" {
 # ── Route tables ─────────────────────────────────────────────────────────────────
 
 resource "oci_core_route_table" "public_rt" {
-  compartment_id = var.compartment_ocid
+  compartment_id = local.effective_compartment_ocid
   vcn_id         = oci_core_vcn.vcn.id
   display_name   = "${local.cluster_name}-public-rt"
   freeform_tags  = local.freeform_tags
@@ -66,7 +66,7 @@ resource "oci_core_route_table" "public_rt" {
 }
 
 resource "oci_core_route_table" "private_rt" {
-  compartment_id = var.compartment_ocid
+  compartment_id = local.effective_compartment_ocid
   vcn_id         = oci_core_vcn.vcn.id
   display_name   = "${local.cluster_name}-private-rt"
   freeform_tags  = local.freeform_tags
@@ -93,7 +93,7 @@ resource "oci_core_route_table" "private_rt" {
 
 # Public subnet security list — API endpoint + LB traffic
 resource "oci_core_security_list" "public_sl" {
-  compartment_id = var.compartment_ocid
+  compartment_id = local.effective_compartment_ocid
   vcn_id         = oci_core_vcn.vcn.id
   display_name   = "${local.cluster_name}-public-sl"
   freeform_tags  = local.freeform_tags
@@ -140,7 +140,7 @@ resource "oci_core_security_list" "public_sl" {
 # Private subnet security list — worker nodes (no direct API port exposure)
 # CIS: private nodes must not accept inbound API traffic from internet.
 resource "oci_core_security_list" "private_sl" {
-  compartment_id = var.compartment_ocid
+  compartment_id = local.effective_compartment_ocid
   vcn_id         = oci_core_vcn.vcn.id
   display_name   = "${local.cluster_name}-private-sl"
   freeform_tags  = local.freeform_tags
@@ -173,7 +173,7 @@ resource "oci_core_security_list" "private_sl" {
 # ── Network Security Group (OKE cluster endpoint) ─────────────────────────────────
 
 resource "oci_core_network_security_group" "oke_cluster_nsg" {
-  compartment_id = var.compartment_ocid
+  compartment_id = local.effective_compartment_ocid
   vcn_id         = oci_core_vcn.vcn.id
   display_name   = "${local.cluster_name}-oke-cluster-nsg"
   freeform_tags  = local.freeform_tags
@@ -278,7 +278,7 @@ resource "oci_core_network_security_group_security_rule" "oke_cluster_nsg_egress
 # ── Subnets ───────────────────────────────────────────────────────────────────────
 
 resource "oci_core_subnet" "public_subnet" {
-  compartment_id             = var.compartment_ocid
+  compartment_id             = local.effective_compartment_ocid
   vcn_id                     = oci_core_vcn.vcn.id
   cidr_block                 = "10.0.1.0/24"
   display_name               = "${local.cluster_name}-public"
@@ -290,7 +290,7 @@ resource "oci_core_subnet" "public_subnet" {
 }
 
 resource "oci_core_subnet" "private_subnet" {
-  compartment_id             = var.compartment_ocid
+  compartment_id             = local.effective_compartment_ocid
   vcn_id                     = oci_core_vcn.vcn.id
   cidr_block                 = "10.0.2.0/24"
   display_name               = "${local.cluster_name}-private"
@@ -305,7 +305,7 @@ resource "oci_core_subnet" "private_subnet" {
 
 resource "oci_logging_log_group" "vcn_flow_logs" {
   count          = var.enable_flow_logs ? 1 : 0
-  compartment_id = var.compartment_ocid
+  compartment_id = local.effective_compartment_ocid
   display_name   = "${local.cluster_name}-vcn-flow-logs"
   freeform_tags  = local.freeform_tags
 }
@@ -324,7 +324,7 @@ resource "oci_logging_log" "public_subnet_flow_log" {
       service     = "flowlogs"
       source_type = "OCISERVICE"
     }
-    compartment_id = var.compartment_ocid
+    compartment_id = local.effective_compartment_ocid
   }
 
   is_enabled         = true
@@ -345,7 +345,7 @@ resource "oci_logging_log" "private_subnet_flow_log" {
       service     = "flowlogs"
       source_type = "OCISERVICE"
     }
-    compartment_id = var.compartment_ocid
+    compartment_id = local.effective_compartment_ocid
   }
 
   is_enabled         = true

--- a/tf/node-pool.tf
+++ b/tf/node-pool.tf
@@ -1,7 +1,7 @@
 # ── Data sources ──────────────────────────────────────────────────────────────────
 
 data "oci_identity_availability_domains" "ads" {
-  compartment_id = var.compartment_ocid
+  compartment_id = local.effective_compartment_ocid
 }
 
 # OKE-prebuilt worker images for this cluster.
@@ -13,7 +13,7 @@ data "oci_identity_availability_domains" "ads" {
 # sources newest-first so element [0] is always the latest available build.
 data "oci_containerengine_node_pool_option" "oke" {
   node_pool_option_id = oci_containerengine_cluster.arm_cluster.id
-  compartment_id      = var.compartment_ocid
+  compartment_id      = local.effective_compartment_ocid
 }
 
 locals {
@@ -32,7 +32,7 @@ locals {
 # node_pool_kubernetes_version to lag behind during staged upgrades.
 
 resource "oci_containerengine_node_pool" "arm_pool" {
-  compartment_id     = var.compartment_ocid
+  compartment_id     = local.effective_compartment_ocid
   cluster_id         = oci_containerengine_cluster.arm_cluster.id
   kubernetes_version = local.node_pool_kubernetes_version
   name               = "${local.cluster_name}-arm-pool"

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -18,7 +18,7 @@ output "api_endpoint" {
 
 output "kubeconfig_command" {
   description = "Run this command to configure kubectl for the cluster."
-  value       = "oci ce cluster create-kubeconfig --cluster-id ${oci_containerengine_cluster.arm_cluster.id} --file ~/.kube/config --region ${var.region} --token-version 2.0.0 --context-name ${oci_containerengine_cluster.arm_cluster.name}"
+  value       = "oci ce cluster create-kubeconfig --cluster-id ${oci_containerengine_cluster.arm_cluster.id} --file ~/.kube/config --region ${local.effective_region} --token-version 2.0.0 --context-name ${oci_containerengine_cluster.arm_cluster.name}"
 }
 
 # ── Kubernetes versions ───────────────────────────────────────────────────────────
@@ -47,7 +47,7 @@ output "vcn_id" {
 
 output "cluster_region" {
   description = "OCI region of the cluster."
-  value       = var.region
+  value       = local.effective_region
 }
 
 # ── Node pool ─────────────────────────────────────────────────────────────────────
@@ -82,4 +82,22 @@ output "grafana_url" {
 output "prometheus_url" {
   description = "Prometheus access URL (port-forward or LoadBalancer)."
   value       = module.monitoring.prometheus_url
+}
+
+output "grafana_admin_password" {
+  description = "Grafana admin password (auto-generated if not supplied). Retrieve with: tofu output -raw grafana_admin_password"
+  value       = local.effective_grafana_password
+  sensitive   = true
+}
+
+# ── Resolved configuration ────────────────────────────────────────────────────
+
+output "compartment_ocid_in_use" {
+  description = "Compartment OCID actually used (resolved from var or ~/.oci/config)."
+  value       = local.effective_compartment_ocid
+}
+
+output "region_in_use" {
+  description = "OCI region actually used (resolved from var or ~/.oci/config)."
+  value       = local.effective_region
 }

--- a/tf/provider.tf
+++ b/tf/provider.tf
@@ -16,14 +16,20 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 3.1.1"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6.0"
+    }
   }
 }
 
 # ── OCI provider ────────────────────────────────────────────────────────────────
-# Reads tenancy/user/region from ~/.oci/config automatically when fingerprint
-# and private_key_path are null (the default). Override via variables for CI.
+# region is derived from local.effective_region (var.region > ~/.oci/config).
+# tenancy/user/fingerprint/key are read from ~/.oci/config automatically when
+# fingerprint and private_key_path are null (the default).
+# Override via variables for CI or multi-tenancy setups.
 provider "oci" {
-  region           = var.region
+  region           = local.effective_region
   fingerprint      = var.fingerprint
   private_key_path = var.private_key_path
 }
@@ -55,7 +61,7 @@ provider "kubernetes" {
     args = [
       "ce", "cluster", "generate-token",
       "--cluster-id", oci_containerengine_cluster.arm_cluster.id,
-      "--region", var.region
+      "--region", local.effective_region
     ]
   }
 }
@@ -72,7 +78,7 @@ provider "helm" {
       args = [
         "ce", "cluster", "generate-token",
         "--cluster-id", oci_containerengine_cluster.arm_cluster.id,
-        "--region", var.region
+        "--region", local.effective_region
       ]
     }
   }

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -1,16 +1,33 @@
 # ── Authentication & tenancy ────────────────────────────────────────────────────
-# The OCI provider reads ~/.oci/config automatically when these are left null.
+# The OCI provider reads tenancy/user/fingerprint/key from ~/.oci/config
+# automatically (DEFAULT profile) when these are left null.
 # Override only when running in CI or multi-tenancy setups.
 
-variable "region" {
-  description = "OCI region for the cluster."
+variable "oci_profile" {
+  description = "OCI config profile name to read from ~/.oci/config. Defaults to DEFAULT."
   type        = string
-  default     = "uk-london-1"
+  default     = "DEFAULT"
+}
+
+variable "region" {
+  description = <<-EOT
+    OCI region for the cluster.
+    If null (default), the region is read from ~/.oci/config ([oci_profile] stanza).
+    Override with e.g. -var='region=us-ashburn-1'.
+  EOT
+  type        = string
+  default     = null
 }
 
 variable "compartment_ocid" {
-  description = "OCID of the compartment to deploy into. Required."
+  description = <<-EOT
+    OCID of the compartment to deploy into.
+    If null (default), uses the tenancy OCID from ~/.oci/config, which is also
+    the root compartment OCID — suitable for personal and demo tenancies.
+    Override to deploy into a sub-compartment.
+  EOT
   type        = string
+  default     = null
 }
 
 variable "fingerprint" {
@@ -110,7 +127,14 @@ variable "enable_flow_logs" {
 # ── Monitoring ──────────────────────────────────────────────────────────────────
 
 variable "grafana_admin_password" {
-  description = "Admin password for Grafana. Must be set — no default for security reasons."
+  description = <<-EOT
+    Admin password for Grafana.
+    If null (default), a 24-character random password is generated automatically
+    and exposed via `tofu output -raw grafana_admin_password`.
+    Pass -var='grafana_admin_password=...' or set TF_VAR_grafana_admin_password
+    to supply your own password.
+  EOT
   type        = string
+  default     = null
   sensitive   = true
 }


### PR DESCRIPTION
## Summary

- **Zero-argument apply**: `tofu apply` now works with no `-var` flags for typical local development
- `region` and `compartment_ocid` are auto-read from `~/.oci/config` (same file the OCI CLI uses)
- `grafana_admin_password` is auto-generated (24-char random, stored in state) when not supplied; retrieve with `tofu output -raw grafana_admin_password`
- Full backwards compatibility — existing `-var` / `TF_VAR_*` / `terraform.tfvars` values continue to work unchanged

## Precedence

```
-var flag / TF_VAR_* > terraform.tfvars > ~/.oci/config > error (clear message)
```

## What changed

| File | Change |
|------|--------|
| `tf/variables.tf` | `region`, `compartment_ocid`, `grafana_admin_password` now `default = null`; new `oci_profile` var |
| `tf/locals.tf` | Pure-HCL regex parsing of `~/.oci/config`; `effective_region`, `effective_compartment_ocid`, `effective_grafana_password` locals; `random_password.grafana` resource; `check` block with friendly error |
| `tf/provider.tf` | `region = local.effective_region`; added `hashicorp/random >= 3.6.0` |
| `tf/cluster.tf`, `network.tf`, `node-pool.tf` | `var.compartment_ocid` → `local.effective_compartment_ocid` |
| `tf/outputs.tf` | `var.region` → `local.effective_region`; new `grafana_admin_password`, `compartment_ocid_in_use`, `region_in_use` outputs |
| `tf/main.tf` | `grafana_admin_password = local.effective_grafana_password` |
| `README.md` | Quick Start: 3 commands; new Authentication & defaults section |
| `tf/README.md` | Zero-arg Quick Start; OCI config auto-discovery section |

## Verified

- `tofu fmt` clean
- `tofu validate` Success
- `tofu plan` (zero args) auto-resolves `region=uk-london-1` and `compartment_ocid` from `~/.oci/config` — no `-var` flags needed
- Plan shows 2 expected changes: `random_password.grafana[0]` (new) + Helm release password rotation (`placeholder` → generated value)