### PR TITLE
docs: trim and deduplicate READMEs across root, tf/, and modules/monitoring/

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Security Scan](https://github.com/idvoretskyi/oci-arm-k8s/actions/workflows/security-scan.yml/badge.svg)](https://github.com/idvoretskyi/oci-arm-k8s/actions/workflows/security-scan.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-OpenTofu configuration for a **$0/month** ARM-based OKE demo cluster on Oracle Cloud Infrastructure, sized for the Always Free tier, auto-upgrading to the latest Kubernetes version on each apply.
+A `$0/month` reference cluster on OCI Always Free for CNCF demos and ARM64 experimentation. One `tofu apply` — no flags, no manual config — gives you a single-node ARM OKE cluster with Prometheus and Grafana, auto-upgrading to the latest Kubernetes version. Not intended for production.
 
 ## Quick Start
 
-Requires: OCI CLI configured (`~/.oci/config`), [OpenTofu](https://opentofu.org) 1.6+, `kubectl`.
+**Prerequisites:** [OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm) configured (`~/.oci/config`), [OpenTofu](https://opentofu.org) 1.6+, `kubectl`.
 
 ```bash
 cd tf
@@ -15,7 +15,7 @@ tofu init
 tofu apply
 ```
 
-That's it — no `-var` flags needed. Region, tenancy/compartment, and Grafana password are all resolved automatically (see [Authentication & defaults](#authentication--defaults) below).
+Region, compartment, and Grafana password are all resolved from `~/.oci/config` — no `-var` flags needed. See [`tf/README.md`](tf/README.md) for override options.
 
 Configure kubectl:
 ```bash
@@ -23,7 +23,7 @@ eval "$(tofu output -raw kubeconfig_command)"
 kubectl get nodes -o wide
 ```
 
-Retrieve the auto-generated Grafana password:
+Get the Grafana password:
 ```bash
 tofu output -raw grafana_admin_password
 ```
@@ -31,105 +31,33 @@ tofu output -raw grafana_admin_password
 ## What You Get
 
 - **ARM node** — 1 × VM.Standard.A1.Flex (2 OCPU, 12 GB RAM), Always Free; OKE Basic cluster (free)
-- **Network** — public subnet (API endpoint + LB) + private subnet (workers); NAT Gateway for internet egress (free on OCI); OCI Service Gateway for low-latency OCI Registry access
-- **Auto-upgrade** — `kubernetes_version = null` (default) tracks latest OKE version in the region; pin or stage upgrades via variables
-- **Monitoring** — kube-prometheus-stack (Grafana + Prometheus) + metrics-server, tuned for the single demo node
-- **CIS baseline** — split security lists, `api_allowed_cidrs`, tagging, flow logs opt-in; see [`docs/cis-compliance.md`](docs/cis-compliance.md)
-
-## Authentication & defaults
-
-All values are auto-discovered from `~/.oci/config` (the same file used by the OCI CLI). Precedence for each value (highest wins):
-
-| Source | How |
-|--------|-----|
-| Explicit `-var` flag or `TF_VAR_*` env var | `-var='region=us-ashburn-1'` |
-| `terraform.tfvars` / `*.auto.tfvars` (gitignored) | `region = "us-ashburn-1"` |
-| `~/.oci/config` profile (default: `DEFAULT`) | auto-read by OpenTofu |
-| Error | friendly message if value cannot be resolved |
-
-The profile used defaults to `DEFAULT`. Override with `-var='oci_profile=MYPROFILE'`.
-
-**What is auto-discovered:**
-
-| Value | Source |
-|-------|--------|
-| `region` | `region` key in `~/.oci/config` |
-| `compartment_ocid` | `tenancy` key in `~/.oci/config` (= root compartment OCID) |
-| `grafana_admin_password` | 24-char random password, generated once and stored in state |
-| API credentials (user, fingerprint, key) | Read directly by the OCI provider from `~/.oci/config` |
-
-To override any value, pass it as a variable:
-```bash
-tofu apply \
-  -var='compartment_ocid=ocid1.compartment.oc1..xxx' \
-  -var='region=us-ashburn-1' \
-  -var='grafana_admin_password=mysecret'
-```
-
-Or create a gitignored `terraform.tfvars`:
-```hcl
-compartment_ocid       = "ocid1.compartment.oc1..xxx"
-region                 = "us-ashburn-1"
-grafana_admin_password = "mysecret"
-```
-
-## Configuration
-
-Key variables (full list in [`tf/variables.tf`](tf/variables.tf)):
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `oci_profile` | `DEFAULT` | Profile name to read from `~/.oci/config` |
-| `compartment_ocid` | `null` (from `~/.oci/config`) | OCI compartment OCID; defaults to root compartment |
-| `region` | `null` (from `~/.oci/config`) | Deployment region |
-| `kubernetes_version` | `null` (latest) | Pin with e.g. `"v1.31.1"`; null = auto-upgrade |
-| `api_allowed_cidrs` | `["0.0.0.0/0"]` | Restrict API access to operator CIDRs (CIS K8s 5.4.2) |
-| `enable_nat_gateway` | `true` | NAT gateway for private worker egress. **Free on OCI**. |
-| `grafana_admin_password` | `null` (auto-generated) | Retrieve with `tofu output -raw grafana_admin_password` |
+- **Network** — public subnet (API + LB) + private subnet (workers); NAT Gateway (free on OCI); OCI Service Gateway for registry access
+- **Auto-upgrade** — tracks the latest OKE version in the region on every `tofu apply`
+- **Monitoring** — kube-prometheus-stack (Grafana + Prometheus) + metrics-server, tuned for the demo node
+- **CIS baseline** — split security lists, `api_allowed_cidrs`, resource tagging; see [`docs/cis-compliance.md`](docs/cis-compliance.md)
 
 ## Cost
 
-Stays at **$0/month** on OCI Always Free. The NAT gateway has no hourly charge on OCI — only outbound data transfer applies, which is free up to 10 TB/month.
-
-## Upgrading Kubernetes
-
-By default every `tofu apply` upgrades to the latest available version. To stage the upgrade (cluster first, node pool after validation):
-
-```hcl
-# Step 1 — pin node pool while cluster upgrades
-node_pool_kubernetes_version = "v1.30.1"
-
-# Step 2 — once validated, remove the pin and re-apply
-node_pool_kubernetes_version = null
-```
-
-Check what version is available:
-```bash
-tofu output latest_available_kubernetes_version
-```
+**$0/month** on OCI Always Free. The NAT gateway has no hourly charge — only outbound data transfer applies, free up to 10 TB/month.
 
 ## Monitoring
 
 ```bash
 kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80
-# open http://localhost:3000
-# username: admin
-# password: $(tofu output -raw grafana_admin_password)
+# http://localhost:3000  admin / $(tofu output -raw grafana_admin_password)
 ```
 
 ## Troubleshooting
 
-**ARM capacity limited**: OCI Always Free ARM capacity can be constrained. Retry later or try a different region (`us-ashburn-1` often has more capacity).
-
-**Images not pulling**: Worker nodes use the NAT gateway for internet egress. If you disabled it (`enable_nat_gateway = false`), only OCI Registry is reachable via Service Gateway. Re-enable NAT or supply your own image mirror.
-
-**Cluster not ready after apply**: The `oci` CLI is required for exec-based auth. Ensure it is installed and `~/.oci/config` is valid.
-
-**region/compartment not resolved**: If `~/.oci/config` is missing or the profile doesn't exist, OpenTofu will print a clear error. Pass the values explicitly via `-var` or create a `terraform.tfvars`.
+- **ARM capacity unavailable** — OCI Always Free ARM quota can be constrained; retry later or switch region (`us-ashburn-1` usually has more capacity).
+- **Images not pulling** — NAT gateway is required for DockerHub/GitHub pulls; ensure `enable_nat_gateway = true` (the default).
+- **kubectl auth fails** — the `oci` CLI must be installed and `~/.oci/config` must be valid; exec-based token generation depends on it.
+- **region/compartment not resolved** — if `~/.oci/config` is missing or malformed, OpenTofu prints a clear error; pass values via `-var` or `terraform.tfvars`.
 
 ## Further Reading
 
-- [`tf/README.md`](tf/README.md) — deep-dive on configuration and upgrade workflow
+- [`tf/README.md`](tf/README.md) — configuration reference, variable overrides, upgrade workflow
+- [`modules/monitoring/README.md`](modules/monitoring/README.md) — monitoring module API
 - [`docs/cis-compliance.md`](docs/cis-compliance.md) — CIS control mapping
 
 ## License

--- a/modules/monitoring/README.md
+++ b/modules/monitoring/README.md
@@ -1,4 +1,4 @@
-# Monitoring Module for OKE
+# Monitoring Module
 
 Deploys [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) (Grafana + Prometheus + Node Exporter + kube-state-metrics) onto an OKE ARM cluster.
 
@@ -10,8 +10,8 @@ Tuned for a single ARM A1.Flex demo node (2 OCPU / 12 GB RAM) within the OCI Alw
 - **Grafana** — pre-configured dashboards with persistent storage
 - **Node Exporter** — host-level metrics
 - **Kube State Metrics** — Kubernetes object metrics
-- **Alertmanager** — disabled by default (saves ~150 MB RAM on demo node)
-- **ARM64** — all components scheduled on ARM nodes via global nodeSelector
+- **Alertmanager** — disabled by default (saves ~150 MB RAM on the demo node)
+- **ARM64** — all components scheduled on ARM nodes via global `nodeSelector`
 
 ## Usage
 
@@ -21,7 +21,7 @@ module "monitoring" {
 
   create_storage_class   = true
   storage_class          = "oci-bv-paravirtualized"
-  grafana_admin_password = var.grafana_admin_password
+  grafana_admin_password = local.effective_grafana_password  # auto-generated when null
 }
 ```
 
@@ -44,42 +44,62 @@ module "monitoring" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| grafana_admin_password | Grafana admin password | `string` | n/a | yes |
-| monitoring_namespace | Kubernetes namespace | `string` | `"monitoring"` | no |
-| chart_version | kube-prometheus-stack chart version | `string` | `"65.8.1"` | no |
-| storage_class | Storage class for PVs | `string` | `"oci-bv-paravirtualized"` | no |
-| prometheus_storage_size | Prometheus PV size | `string` | `"50Gi"` | no |
-| prometheus_retention | Prometheus retention period | `string` | `"3d"` | no |
-| grafana_storage_size | Grafana PV size | `string` | `"50Gi"` | no |
-| grafana_service_type | Grafana service type | `string` | `"ClusterIP"` | no |
-| grafana_ingress_enabled | Enable Grafana ingress | `bool` | `false` | no |
-| node_exporter_enabled | Enable node-exporter | `bool` | `true` | no |
-| kube_state_metrics_enabled | Enable kube-state-metrics | `bool` | `true` | no |
+| `grafana_admin_password` | Grafana admin password | `string` | n/a | yes |
+| `monitoring_namespace` | Kubernetes namespace | `string` | `"monitoring"` | no |
+| `release_name` | Helm release name | `string` | `"kube-prometheus-stack"` | no |
+| `chart_version` | kube-prometheus-stack chart version | `string` | `"65.8.1"` | no |
+| `helm_timeout` | Helm install/upgrade timeout (seconds) | `number` | `900` | no |
+| `storage_class` | Storage class for PVs | `string` | `"oci-bv-paravirtualized"` | no |
+| `create_storage_class` | Create the OCI Block Volume storage class | `bool` | `false` | no |
+| `prometheus_storage_size` | Prometheus PV size | `string` | `"50Gi"` | no |
+| `prometheus_retention` | Prometheus retention period | `string` | `"3d"` | no |
+| `prometheus_retention_size` | Prometheus retention size limit | `string` | `"8GiB"` | no |
+| `grafana_storage_size` | Grafana PV size | `string` | `"50Gi"` | no |
+| `grafana_persistence_enabled` | Enable Grafana persistent storage | `bool` | `true` | no |
+| `grafana_service_type` | Grafana service type (`ClusterIP`, `NodePort`, `LoadBalancer`) | `string` | `"ClusterIP"` | no |
+| `grafana_ingress_enabled` | Enable Grafana ingress | `bool` | `false` | no |
+| `grafana_hostname` | Grafana ingress hostname | `string` | `"grafana.example.com"` | no |
+| `grafana_ingress_annotations` | Grafana ingress annotations | `map(string)` | `{}` | no |
+| `grafana_ingress_tls_enabled` | Enable TLS on Grafana ingress | `bool` | `false` | no |
+| `prometheus_ingress_enabled` | Enable Prometheus ingress | `bool` | `false` | no |
+| `prometheus_hostname` | Prometheus ingress hostname | `string` | `"prometheus.example.com"` | no |
+| `prometheus_ingress_annotations` | Prometheus ingress annotations | `map(string)` | `{}` | no |
+| `prometheus_ingress_tls_enabled` | Enable TLS on Prometheus ingress | `bool` | `false` | no |
+| `ingress_class` | Ingress class name | `string` | `"nginx"` | no |
+| `node_exporter_enabled` | Enable node-exporter | `bool` | `true` | no |
+| `kube_state_metrics_enabled` | Enable kube-state-metrics | `bool` | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| monitoring_namespace | Namespace of monitoring components |
-| grafana_url | URL to access Grafana |
-| prometheus_url | URL to access Prometheus |
-| grafana_service_name | Grafana Kubernetes service name |
-| prometheus_service_name | Prometheus Kubernetes service name |
-| monitoring_endpoints | Cluster-local service endpoints (grafana_service, prometheus_service) |
+| `monitoring_namespace` | Namespace of monitoring components |
+| `helm_release_name` | Helm release name |
+| `helm_release_version` | Deployed chart version |
+| `helm_release_status` | Helm release status |
+| `grafana_url` | Grafana access command or ingress URL |
+| `prometheus_url` | Prometheus access command or ingress URL |
+| `grafana_service_name` | Grafana Kubernetes service name |
+| `prometheus_service_name` | Prometheus Kubernetes service name |
+| `grafana_admin_password` | Grafana admin password (sensitive) |
+| `grafana_ingress_hostname` | Grafana ingress hostname (null if ingress disabled) |
+| `prometheus_ingress_hostname` | Prometheus ingress hostname (null if ingress disabled) |
+| `storage_class` | Storage class in use |
+| `monitoring_endpoints` | Cluster-local service FQDNs (`grafana_service`, `prometheus_service`) |
 
 ## Accessing Services (demo defaults — ClusterIP)
 
 ```bash
-# Grafana
+# Grafana — http://localhost:3000
 kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80
 
-# Prometheus
+# Prometheus — http://localhost:9090
 kubectl port-forward -n monitoring svc/kube-prometheus-stack-kube-prom-prometheus 9090:9090
 ```
 
 Login: `admin` / `<grafana_admin_password>`
 
-## Resource footprint (demo node: 2 OCPU / 12 GB)
+## Resource Footprint (demo node: 2 OCPU / 12 GB)
 
 | Component | CPU req | Memory req |
 |-----------|---------|------------|
@@ -90,4 +110,4 @@ Login: `admin` / `<grafana_admin_password>`
 | Kube State Metrics | 20m | 64Mi |
 | **Total** | **~240m** | **~864Mi** |
 
-This leaves ~11 GB for demo workloads on the 12 GB node.
+Leaves ~11 GB for demo workloads on the 12 GB node.

--- a/tf/README.md
+++ b/tf/README.md
@@ -24,9 +24,14 @@ tofu init
 tofu apply   # zero args — reads ~/.oci/config automatically
 ```
 
-Retrieve the Grafana password after apply:
+Get the Grafana password:
 ```bash
 tofu output -raw grafana_admin_password
+```
+
+Tear down:
+```bash
+tofu destroy
 ```
 
 ## OCI config auto-discovery
@@ -35,24 +40,23 @@ Values are resolved in this order (highest priority first):
 
 1. Explicit `-var` flag or `TF_VAR_*` environment variable
 2. `terraform.tfvars` / `*.auto.tfvars` (gitignored)
-3. `~/.oci/config` — profile specified by `var.oci_profile` (default: `DEFAULT`)
+3. `~/.oci/config` — profile set by `oci_profile` variable (default: `DEFAULT`)
 4. Error with a descriptive message
 
 | Value | Auto-source |
 |-------|-------------|
 | `region` | `region` key in the config profile |
-| `compartment_ocid` | `tenancy` key (root compartment OCID) |
+| `compartment_ocid` | `tenancy` key (= root compartment OCID) |
 | `grafana_admin_password` | 24-char random password, stable across applies |
-| API credentials | Read by the OCI provider natively from `~/.oci/config` |
+| API credentials (user, fingerprint, key) | Read natively by the OCI provider |
 
-To use a non-default profile:
+Use a non-default profile:
 ```bash
 tofu apply -var='oci_profile=MYPROFILE'
 ```
 
-To override individual values:
+Override individual values via `terraform.tfvars` (gitignored):
 ```hcl
-# terraform.tfvars (gitignored)
 compartment_ocid       = "ocid1.compartment.oc1..xxx"
 region                 = "us-ashburn-1"
 grafana_admin_password = "mysecret"
@@ -60,95 +64,97 @@ grafana_admin_password = "mysecret"
 
 ## Key Variables
 
+Full list in [`variables.tf`](variables.tf). Common overrides:
+
 ```hcl
-# OCI config profile (default: reads [DEFAULT] from ~/.oci/config)
+# OCI profile (default: [DEFAULT] in ~/.oci/config)
 oci_profile = "DEFAULT"
 
 # Region and compartment: null = auto-discovered from ~/.oci/config
 region           = null
 compartment_ocid = null
 
-# Cluster defaults — no changes needed for a basic demo
+# Cluster
 cluster_name   = "arm-oke-demo"
 node_count     = 1
 node_ocpus     = 2
 node_memory_gb = 12
 
-# K8s version: null = always latest, auto-upgrades on each apply
+# Kubernetes version: null = always latest, auto-upgrades on each apply
 kubernetes_version           = null
 node_pool_kubernetes_version = null   # follows cluster by default
 
-# CIS: restrict API to specific IPs (default open for demo)
+# CIS: restrict API server access (default open for demo)
 api_allowed_cidrs = ["0.0.0.0/0"]
 
-# NAT gateway: free on OCI (no hourly charge); enabled by default for outbound egress
+# NAT gateway: free on OCI; required for DockerHub/GitHub image pulls
 enable_nat_gateway = true
 
-# CIS: enable VCN flow logs
+# VCN flow logs (CIS OCI 4.x — minor log-storage cost)
 enable_flow_logs = false
 
-# Grafana password: null = auto-generated; retrieve with: tofu output -raw grafana_admin_password
+# Grafana password: null = auto-generated
 grafana_admin_password = null
 ```
 
 ## Upgrading Kubernetes
 
-Auto-upgrade is on by default. Every `tofu apply` checks the latest version
-available in the region and upgrades if a newer version exists.
+Auto-upgrade is on by default — every `tofu apply` upgrades if OCI has published a newer version.
 
-### Full upgrade (both cluster and node pool together)
-
+Check what is available:
 ```bash
-tofu apply  # both cluster and node pool upgrade in sequence
+tofu output latest_available_kubernetes_version
 ```
 
-### Staged upgrade (cluster first, node pool second)
+### Full upgrade (cluster + node pool together)
 
 ```bash
-# 1. Lock node pool at current version
-tofu apply -var='node_pool_kubernetes_version=v1.30.1'
+tofu apply
+```
 
-# 2. After cluster upgrade completes and validates, release the lock
-tofu apply  # node pool now catches up
+### Staged upgrade (cluster first, node pool after validation)
+
+```bash
+# 1. Lock node pool at its current version while cluster upgrades
+tofu apply -var='node_pool_kubernetes_version=v1.34.2'
+
+# 2. After the cluster upgrade validates, release the lock
+tofu apply
 ```
 
 ### Pin to a specific version
 
 ```bash
-tofu apply -var='kubernetes_version=v1.31.1'
+tofu apply -var='kubernetes_version=v1.35.2'
 ```
 
-### Check available versions
-
-```bash
-tofu output latest_available_kubernetes_version
-```
+> Version examples use values current at time of writing. Check `tofu output latest_available_kubernetes_version` to see what your region offers today.
 
 ## Verify Cluster
 
 ```bash
-# Configure kubectl from outputs
 eval "$(tofu output -raw kubeconfig_command)"
-
 kubectl get nodes -o wide
 kubectl top nodes
 kubectl get pods -A
 ```
 
-## Cleanup
+## Monitoring
+
+Deployed via [`modules/monitoring`](../modules/monitoring/README.md) — kube-prometheus-stack (Grafana + Prometheus + Node Exporter + kube-state-metrics), tuned for the single ARM demo node.
 
 ```bash
-tofu destroy
+# Grafana — http://localhost:3000  admin / $(tofu output -raw grafana_admin_password)
+kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80
+
+# Prometheus — http://localhost:9090
+kubectl port-forward -n monitoring svc/kube-prometheus-stack-kube-prom-prometheus 9090:9090
 ```
 
 ## ARM Notes
 
-- Worker nodes use OKE-prebuilt Oracle Linux 8.10 aarch64 images. These ship with
-  kubelet, containerd, and OCI agents preinstalled and version-locked to the control
-  plane. Oracle Linux 8.10 is the only OKE-blessed ARM64 worker OS; OL9/OL10/Ubuntu
-  aarch64 images exist in OCI but are not offered as OKE-prebuilt worker images.
-  The latest available build for the cluster K8s version is selected automatically.
+- Worker nodes use OKE-prebuilt Oracle Linux 8.10 aarch64 images — kubelet, containerd, and OCI agents are preinstalled and version-locked to the control plane. OL 8.10 is the only OKE-blessed ARM64 worker OS today; OL9/OL10/Ubuntu aarch64 exist in OCI but are not offered as OKE-prebuilt images. The latest build for the cluster K8s version is selected automatically.
 - All container images must support `linux/arm64`. Most upstream images are multi-arch.
 - Java / JVM workloads run unchanged on ARM.
-- Compiled Go / Rust binaries must be built for `GOARCH=arm64`.
-- Node is pre-labeled `kubernetes.io/arch=arm64` for nodeSelector use.
+- Go / Rust binaries must target `GOARCH=arm64`.
+- Nodes are pre-labeled `kubernetes.io/arch=arm64` for `nodeSelector` use.


### PR DESCRIPTION
## Summary

- Root `README.md` cut from **137 → 65 lines** — try-it-now landing page; all detail moved to `tf/README.md`
- `tf/README.md` is now the **single canonical reference** for auth precedence, config overrides, variable table, and upgrade workflow
- `modules/monitoring/README.md` inputs/outputs tables **fully audited** against the actual `variables.tf` / `outputs.tf` — previously ~half the interface was undocumented

## What changed per file

| File | Before | After | Δ |
|------|--------|-------|---|
| `README.md` | 137 lines | 65 lines | −72 |
| `tf/README.md` | 154 lines | 160 lines | +6 |
| `modules/monitoring/README.md` | 93 lines | 113 lines | +20 |

### Root `README.md`
- Added "Why this exists" motivation paragraph
- Removed `Authentication & defaults` section (→ `tf/README.md`)
- Removed `Configuration` variables table (→ `tf/README.md`)
- Removed `Upgrading Kubernetes` section (→ `tf/README.md`)
- Troubleshooting condensed to 4-bullet list
- Further Reading now links all three sub-docs

### `tf/README.md`
- Staged-upgrade version examples modernised (`v1.30.1` → `v1.34.2`, `v1.31.1` → `v1.35.2`) with footnote
- Added Monitoring section with port-forward commands + link to `modules/monitoring/README.md`
- `tofu destroy` zero-arg (consistent with zero-arg `tofu apply` from PR #31)

### `modules/monitoring/README.md`
- Usage example updated: `grafana_admin_password = local.effective_grafana_password` (reflects PR #31 auto-generation)
- Inputs table: added 12 previously undocumented variables
- Outputs table: added 7 previously undocumented outputs

## No functional changes

No `.tf` files modified. `tofu fmt -check` and `tofu validate` both pass.